### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-der = { version = "0.3", features = ["big-uint", "derive"], optional = true }
-ecdsa = { version = "0.11", package = "ecdsa", default-features = false, optional = true }
-elliptic-curve = { version = "0.9", default-features = false, optional = true }
+der = { version = "0.4", features = ["bigint", "derive"], optional = true }
+ecdsa = { version = "0.12", package = "ecdsa", default-features = false, optional = true }
+elliptic-curve = { version = "0.10", default-features = false, optional = true }
 p256-cortex-m4-sys = "0.1.0-alpha.2"
 rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.9", default-features = false, optional = true }
 zeroize = { version = "1.2.0", default-features = false, features = ["zeroize_derive"] }
 
 [dependencies.p256]
-version = "0.8"
+version = "0.9"
 default-features = false
 features = ["arithmetic", "ecdh", "ecdsa", "sha256", "zeroize"]
 optional = true

--- a/src/cortex_m4.rs
+++ b/src/cortex_m4.rs
@@ -396,9 +396,9 @@ impl Signature {
     pub fn to_sec1_bytes(&self, buffer: &mut [u8; 72]) -> usize {
         let r = self.r();
         let s = self.s();
-        let signature  = DerSignature {
-            r: der::BigUInt::new(&r).unwrap(),
-            s: der::BigUInt::new(&s).unwrap(),
+        let signature = DerSignature {
+            r: der::asn1::UIntBytes::new(&r).unwrap(),
+            s: der::asn1::UIntBytes::new(&s).unwrap(),
         };
 
         use der::Encodable;
@@ -411,8 +411,8 @@ impl Signature {
 #[cfg_attr(docsrs, doc(cfg(feature = "sec1-signatures")))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, der::Message)]
 struct DerSignature<'a> {
-    pub r: der::BigUInt<'a, der::consts::U32>,
-    pub s: der::BigUInt<'a, der::consts::U32>,
+    pub r: der::asn1::UIntBytes<'a>,
+    pub s: der::asn1::UIntBytes<'a>,
 }
 
 impl SharedSecret {


### PR DESCRIPTION
Tested `sign_prehashed` and `verify_prehashed` functionality on-target with a STM32WL55.

### Changelogs

* [der](https://github.com/RustCrypto/utils/blob/master/der/CHANGELOG.md)
* [ecdsa](https://github.com/RustCrypto/signatures/blob/master/ecdsa/CHANGELOG.md)
* [elliptic-curve](https://github.com/RustCrypto/traits/blob/master/elliptic-curve/CHANGELOG.md)
* [p256](https://github.com/RustCrypto/elliptic-curves/blob/master/p256/CHANGELOG.md)