### PR TITLE
Mark verify methods as must_use

### DIFF
--- a/src/cortex_m4.rs
+++ b/src/cortex_m4.rs
@@ -283,6 +283,7 @@ impl PublicKey {
     }
 
     /// Verify signature on message assumed to be hashed, if needed.
+    #[must_use = "The return value indicates if the message is authentic"]
     pub fn verify_prehashed(&self, prehashed_message: &[u8], signature: &Signature) -> bool {
         unsafe { p256_cortex_m4_sys::p256_verify(
             &self.x[0] as *const u32,
@@ -297,6 +298,7 @@ impl PublicKey {
     /// Verify signature on message, which is hashed with SHA-256 first.
     #[cfg(feature = "prehash")]
     #[cfg_attr(docsrs, doc(cfg(feature = "prehash")))]
+    #[must_use = "The return value indicates if the message is authentic"]
     pub fn verify(&self, message: &[u8], signature: &Signature) -> bool {
         let prehashed_message = sha256(message);
         self.verify_prehashed(prehashed_message.as_ref(), signature)

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -166,6 +166,7 @@ impl PublicKey {
    }
 
    /// Verify signature on message assumed to be hashed, if needed.
+   #[must_use = "The return value indicates if the message is authentic"]
    pub fn verify_prehashed(&self, prehashed_message: &[u8], signature: &Signature) -> bool {
        let prehashed_message_as_scalar = p256::Scalar::from_bytes_reduced(prehashed_message.try_into().unwrap());
        self.0.as_affine().verify_prehashed(&prehashed_message_as_scalar, &signature.0).is_ok()
@@ -174,6 +175,7 @@ impl PublicKey {
    /// Verify signature on message, which is hashed with SHA-256 first.
    #[cfg(feature = "prehash")]
    #[cfg_attr(docsrs, doc(cfg(feature = "prehash")))]
+   #[must_use = "The return value indicates if the message is authentic"]
    pub fn verify(&self, message: &[u8], signature: &Signature) -> bool {
        let verifier: p256::ecdsa::VerifyingKey = self.0.clone().into();
        use p256::ecdsa::signature::Verifier;


### PR DESCRIPTION
The return value of the verify methods should be checked, this change adds a warning if the return value is unused.